### PR TITLE
Release v1.2.1 important fix with cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ use CsrfToken\Security\EncryptedCsrfToken;
 Starting from version `1.1.0` and above, the namespace has changed to:
 
 ```php
-use rafalmasiarek\CsrfToken\EncryptedCsrfToken;
+use rafalmasiarek\Csrf\Csrf;
 ```
 
 **Action required:**  
-If you're upgrading from version `1.0.0`, update all references to `EncryptedCsrfToken` in your codebase to use the new namespace.
+If you're upgrading from version `1.0.0`, update all references to `rafalmasiarek\Csrf\Csrf` in your codebase to use the new namespace.
 
 This change was made to follow proper PSR-4 naming conventions and prevent naming conflicts in larger applications or when used as a dependency.
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   },
   "autoload": {
     "psr-4": {
-      "rafalmasiarek\\CsrfToken\\": "src/"
+      "rafalmasiarek\\Csrf\\": "src/"
     }
   },
   "license": "MIT",

--- a/example/_vendor/autoload.php
+++ b/example/_vendor/autoload.php
@@ -1,0 +1,20 @@
+<?php
+
+spl_autoload_register(function ($class) {
+
+    $prefix = 'rafalmasiarek\\Csrf\\';
+
+    $base_dir = __DIR__ . '/../../src/';
+
+    $len = strlen($prefix);
+    if (strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative_class = substr($class, $len);
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+    if (file_exists($file)) {
+        require $file;
+    }
+});

--- a/example/basic/index.php
+++ b/example/basic/index.php
@@ -1,12 +1,12 @@
 <?php
 session_start();
-require __DIR__ . '/../../vendor/autoload.php';
 
-use rafalmasiarek\CsrfToken\EncryptedCsrfToken;
+require __DIR__ . '/../_vendor/autoload.php';
 
-$key = hash('sha256', 'your-very-secret-key_kmd6xeWlXWF7', true); // 32 bytes
-$csrf = new EncryptedCsrfToken($key);
+use rafalmasiarek\Csrf\Csrf;
 
+$key = hash('sha256', 'your-very-secret-key_kmd6xeWlXWF7', true);
+$csrf = new Csrf($key);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $token = $_POST['csrf_token'] ?? '';
@@ -19,6 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $token = $csrf->generate();
 }
 ?>
+
 <form method="POST">
     <input type="text" name="name" placeholder="Your name" required>
     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token) ?>">

--- a/example/fileCache/index.php
+++ b/example/fileCache/index.php
@@ -1,24 +1,26 @@
 <?php
 session_start();
-require __DIR__ . '/../../vendor/autoload.php';
 
-use rafalmasiarek\CsrfToken\EncryptedCsrfToken;
-use rafalmasiarek\CsrfToken\CsrfCacheWrapper;
-use rafalmasiarek\CsrfToken\Storage\FileStorage;
+require __DIR__ . '/../_vendor/autoload.php';
+
+use rafalmasiarek\Csrf\Csrf;
+use rafalmasiarek\Csrf\CsrfCacheWrapper;
+use rafalmasiarek\Csrf\FileStorage;
 
 $key = hash('sha256', 'your-very-secret-key_kmd6xeWlXWF7', true); // 32 bytes
 
-// Ustaw ścieżkę do katalogu cache
+// Ensure the cache directory exists
+// This directory will be used to store CSRF token files.
 $cachePath = __DIR__ . '/tmp/csrf';
 
-// Jeśli katalog nie istnieje — utwórz go
+// Create the cache directory if it does not exist
 if (!is_dir($cachePath)) {
     mkdir($cachePath, 0700, true);
 }
 
-// Inicjalizacja klas
-$csrfCore = new EncryptedCsrfToken($key);
+$csrfCore = new Csrf($key);
 $fileCache = new FileStorage($cachePath);
+
 $csrf = new CsrfCacheWrapper($csrfCore, $fileCache);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -29,10 +31,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     echo '✅ CSRF token valid. Hello, ' . htmlspecialchars($_POST['name']) . '!';
 } else {
-    // UWAGA: generujemy token z klasy bazowej (nie przez wrapper!)
-    $token = $csrfCore->generate();
+    $token = $csrf->generate();
 }
-
 ?>
 
 <form method="POST">

--- a/src/Csrf.php
+++ b/src/Csrf.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace rafalmasiarek\CsrfToken;
+namespace rafalmasiarek\Csrf;
 
-class EncryptedCsrfToken
+class Csrf
 {
     /**
      * @var string
@@ -54,6 +54,18 @@ class EncryptedCsrfToken
     // the lifetime of the EncryptedCsrfToken instance.
     // This property is useful for applications that need to log or debug CSRF token usage.
     private ?array $lastPayload = null;
+
+    /**
+     * Returns the time-to-live (TTL) for CSRF tokens in seconds.
+     *
+     * This value defines how long a generated CSRF token remains valid.
+     *
+     * @return int The TTL in seconds.
+     */
+    public function getTtl(): int
+    {
+        return $this->ttl;
+    }
 
     /**
      * Constructor for the EncryptedCsrfToken.
@@ -161,7 +173,7 @@ class EncryptedCsrfToken
             return false;
         }
 
-        unset($_SESSION[$this->sessionKey]); // burn after successful validation
+        $this->clear(); // burn after successful validation
         return true;
     }
 
@@ -292,7 +304,7 @@ class EncryptedCsrfToken
      */
     // This private helper method checks if the provided token state is expired or invalid.
     // It is used internally to avoid repeating TTL validation logic in multiple methods.
-    private function isExpired(?array $state): bool
+    public function isExpired(?array $state): bool
     {
         if (!is_array($state) || !isset($state['iat']) || !is_int($state['iat'])) {
             return true;

--- a/src/CsrfStorageInterface.php
+++ b/src/CsrfStorageInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace rafalmasiarek\CsrfToken\Storage;
+namespace rafalmasiarek\Csrf;
 
 interface CsrfStorageInterface
 {

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace rafalmasiarek\CsrfToken\Storage;
+namespace rafalmasiarek\Csrf;
 
 /**
  * FileStorage is a simple file-based implementation of the CsrfStorageInterface.

--- a/src/MysqlStorage.php
+++ b/src/MysqlStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace rafalmasiarek\CsrfToken\Storage;
+namespace rafalmasiarek\Csrf;
 
 use PDO;
 

--- a/src/RedisStorage.php
+++ b/src/RedisStorage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace rafalmasiarek\CsrfToken\Storage;
+namespace rafalmasiarek\Csrf;
 
 use Redis;
 


### PR DESCRIPTION
## Improve CSRF cache wrapper to validate tokens without decryption

- Refactor CsrfCacheWrapper to use cached token metadata (iat and fingerprint) for validation
- Avoid decrypting tokens if valid cached data is available, improving performance
- Add TTL and fingerprint checks directly on cached data to ensure security
- Remove redundant decrypt-and-validate calls when token is cached and fresh
- Keep full decryption only for cache misses or expired tokens, then update cache accordingly
- Prepare groundwork for enhanced stateless CSRF validation and efficient caching