### PR TITLE
Release v1.3.0 with container-aware tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.1', '8.2', '8.3']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, json, openssl, redis
+          coverage: none
+      - run: composer install --no-interaction --prefer-dist
+      - run: vendor/bin/phpunit
+      - run: vendor/bin/phpcs

--- a/README.md
+++ b/README.md
@@ -1,51 +1,142 @@
-# Encrypted CSRF Token Library
+# PHP CSRF — Encrypted, Container‑Aware Tokens
 
-A secure, stateless CSRF protection system using encrypted fingerprints containing:
-- CSRF token
-- Client IP
-- User-Agent
-- Timestamp (`iat`)
-
-Encrypted with AES-256-GCM and compatible with caching layers.
+A secure CSRF protection library with **AES‑256‑GCM** encryption and **per‑form containers**.
+Each form (container) has its own session bucket, derived key (HKDF) and optional pepper.
+Tokens are bound to container id, client IP and User‑Agent (both configurable).
 
 ## Features
 
-- Stateless CSRF token with embedded fingerprint
-- AES-256-GCM encryption with IV and tag
-- `iat` timestamp support (TTL)
-- Optional caching (file, MySQL, Redis)
-- Read-only cache support
-- Garbage collector for file cache
+- Stateless encrypted token (payload: token, ip, ua, iat, container id)
+- AES‑256‑GCM with IV + auth tag, AAD binds to container id/prefix
+- Per‑container isolation: replay across forms is impossible
+- Configurable bindings (IP/UA) per container
+- TTL support (set `0` to disable expiry — not recommended)
+- Optional cache layer (File / MySQL / Redis) for fast‑path validation
+- Backwards compatible API: `generate()`/`validate()` still work for the `"default"` container
 
-## Usage
+## Install
 
-See `examples/` for usage examples.
-
-## Upgrade Notice (from v1.0.0)
-
-In versions prior to `1.1.0`, the default namespace was:
-
-```php
-use CsrfToken\Security\EncryptedCsrfToken;
+```bash
+composer require rafalmasiarek/php-csrf
 ```
 
-Starting from version `1.1.0` and above, the namespace has changed to:
+## Quick Start
 
 ```php
 use rafalmasiarek\Csrf\Csrf;
+
+session_start();
+
+$csrf = new Csrf($masterKey32Bytes, 900); // TTL=900s
+$token = $csrf->generate();               // default container
+// <input type="hidden" name="_csrf" value="$token">
 ```
 
-**Action required:**  
-If you're upgrading from version `1.0.0`, update all references to `rafalmasiarek\Csrf\Csrf` in your codebase to use the new namespace.
+Validation:
 
-This change was made to follow proper PSR-4 naming conventions and prevent naming conflicts in larger applications or when used as a dependency.
-
-## Garbage Collection (File Cache)
-
-```bash
-php bin/garbage_collector.php
+```php
+if (!$csrf->validate($_POST['_csrf'] ?? null)) {
+    http_response_code(419);
+    exit('CSRF verification failed');
+}
 ```
+
+## Containers (Multiple Forms)
+
+```php
+use rafalmasiarek\Csrf\{Csrf, CsrfCacheWrapper, FileStorage};
+
+$csrf = (new Csrf($masterKey32Bytes, 900))
+    ->withContainer('signup', ['prefix' => 'auth_', 'bind_ip' => true,  'bind_ua' => true])
+    ->withContainer('profile', ['prefix' => 'user_', 'bind_ip' => false, 'bind_ua' => true]);
+
+$cache = new FileStorage(__DIR__ . '/var/csrf-cache'); // or MysqlStorage / RedisStorage
+$csrfCached = new CsrfCacheWrapper($csrf, $cache);
+
+// View:
+$tokenSignup = $csrfCached->generateFor('signup');
+$tokenProfile = $csrfCached->generateFor('profile');
+
+// POST handler:
+$ok = $csrfCached->validateFor('signup', $_POST['_csrf'] ?? '');
+```
+
+## Storage Options
+
+- `FileStorage($dir)` — writes JSON files (hashed filenames)
+- `MysqlStorage(PDO $pdo)` — uses table `csrf_cache(token_hash, payload JSON, created_at)`
+- `RedisStorage(Redis $redis, string $prefix = 'csrf:', int $ttl = 900)`
+
+> Storage keys are hashed; for multi‑containers we pass a composite `"<container>|<token>"` to avoid collisions.
+
+## Security Notes
+
+- Keep the **master key** (32 bytes) secret. Rotate periodically.
+- Prefer enabling **IP/UA binding**. Disable only if your environment makes them unstable.
+- Set a **reasonable TTL**. `0` (no expiry) is supported but not recommended.
+- Tokens are **burned after successful validation** (per container).
+
+## Migration
+
+### From 1.1.x → 1.2.0
+
+- **What changed**: The library is now **container‑aware**. Internal session storage moved under `$_SESSION['_csrf_v2'][<prefix><container>]` and tokens are bound to container id via AAD and payload.
+- **Backwards compatibility**: Existing calls to `generate()` / `validate()` continue to work for the implicit `"default"` container.
+- **Recommended**: Start calling `generateFor('<form-id>')` / `validateFor('<form-id>', $token)` for each separate form.
+
+### From 1.0.0 → 1.1.x
+
+- Namespace unified under `rafalmasiarek\Csrf` and PSR‑4 autoloading.
+
+## Examples
+
+See [`example/`](example/) for drop‑in snippets:
+- `basic/index.php`
+- `containers/index.php`
+- `mysql/schema.sql`
 
 ## License
 
 MIT
+
+
+## View Helpers
+
+### Plates (League\Plates)
+```php
+use League\Plates\Engine;
+use rafalmasiarek\Csrf\Csrf;
+use rafalmasiarek\Csrf\Helpers\Plates\CsrfExtension;
+
+$view = new Engine(__DIR__.'/views');
+$csrf = new Csrf($masterKey, 900);
+CsrfExtension::register($view, $csrf);
+
+// In template: <?= csrf_field('signup') ?>
+```
+
+### Twig
+```php
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use rafalmasiarek\Csrf\Csrf;
+use rafalmasiarek\Csrf\Helpers\Twig\CsrfExtension;
+
+$twig = new Environment(new FilesystemLoader(__DIR__.'/views'));
+$csrf = new Csrf($masterKey, 900);
+$twig->addExtension(new CsrfExtension($csrf));
+
+// In template: {{ csrf_field('signup')|raw }}
+```
+
+### Blade (Laravel)
+```php
+use Illuminate\View\Compilers\BladeCompiler;
+use rafalmasiarek\Csrf\Csrf;
+use rafalmasiarek\Csrf\Helpers\Blade\CsrfBlade;
+
+// In a service provider boot():
+CsrfBlade::register($this->app->make(BladeCompiler::class), app(Csrf::class));
+
+// In Blade: @csrfField('signup')
+```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ $ok = $csrfCached->validateFor('signup', $_POST['_csrf'] ?? '');
 
 ## Migration
 
-### From 1.1.x → 1.2.0
+### From 1.2.x → 132.0
 
 - **What changed**: The library is now **container‑aware**. Internal session storage moved under `$_SESSION['_csrf_v2'][<prefix><container>]` and tokens are bound to container id via AAD and payload.
 - **Backwards compatibility**: Existing calls to `generate()` / `validate()` continue to work for the implicit `"default"` container.

--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,13 @@
       "name": "Rafal Maiarek",
       "email": "rafal@masiarek.pl"
     }
-  ]
+  ],
+  "require-dev": {
+    "phpunit/phpunit": "^10.0",
+    "squizlabs/php_codesniffer": "^3.9"
+  },
+  "scripts": {
+    "test": "phpunit",
+    "cs": "phpcs"
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,1763 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33edc86d58289569479c453c1c441af2",
+    "content-hash": "2c65f28f1ff1b3417ed47920fb792057",
     "packages": [],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+            },
+            "time": "2025-10-21T19:32:17+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.58",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.4",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-28T12:04:46+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-07T05:25:07+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
+                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-05T05:47:09+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:36:25+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],

--- a/composer.lock
+++ b/composer.lock
@@ -1763,12 +1763,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/example/basic/index.php
+++ b/example/basic/index.php
@@ -5,8 +5,8 @@ require __DIR__ . '/../_vendor/autoload.php';
 
 use rafalmasiarek\Csrf\Csrf;
 
-$key = hash('sha256', 'your-very-secret-key_kmd6xeWlXWF7', true);
-$csrf = new Csrf($key);
+$key = random_bytes(32);
+$csrf = new Csrf($key, 900);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $token = $_POST['csrf_token'] ?? '';

--- a/example/containers/index.php
+++ b/example/containers/index.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+session_start();
+
+require __DIR__ . '/../_vendor/autoload.php';
+
+use rafalmasiarek\Csrf\{Csrf, CsrfCacheWrapper};
+use rafalmasiarek\Csrf\FileStorage;
+
+$key = random_bytes(32);
+$csrf = (new Csrf($key, 900))
+    ->withContainer('signup',  ['prefix' => 'auth_', 'bind_ip' => true,  'bind_ua' => true])
+    ->withContainer('profile', ['prefix' => 'user_', 'bind_ip' => false, 'bind_ua' => true]);
+
+$cache = new FileStorage(__DIR__ . '/../../var/csrf-cache');
+$wrapper = new CsrfCacheWrapper($csrf, $cache);
+
+$action = $_GET['a'] ?? 'view';
+
+if ($action === 'post' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $container = $_POST['_container'] ?? 'signup';
+    $ok = $wrapper->validateFor($container, $_POST['_csrf'] ?? '');
+    header('Content-Type: text/plain; charset=utf-8');
+    echo $ok ? "OK ({$container})" : "CSRF FAIL ({$container})";
+    exit;
+}
+
+// Render simple demo page
+function input(Csrf $csrf, string $container): string {
+    $t = $csrf->generateFor($container);
+    return sprintf('<input type="hidden" name="_csrf" value="%s"><input type="hidden" name="_container" value="%s">',
+        htmlspecialchars($t, ENT_QUOTES), htmlspecialchars($container, ENT_QUOTES));
+}
+?>
+<!doctype html>
+<html>
+<head><meta charset="utf-8"><title>CSRF Containers Demo</title></head>
+<body>
+  <h1>CSRF Containers Demo</h1>
+
+  <h2>Signup form</h2>
+  <form method="post" action="?a=post">
+    <?= input($csrf, 'signup') ?>
+    <button>Send</button>
+  </form>
+
+  <h2>Profile form</h2>
+  <form method="post" action="?a=post">
+    <?= input($csrf, 'profile') ?>
+    <button>Send</button>
+  </form>
+</body>
+</html>

--- a/example/mysql/schema.sql
+++ b/example/mysql/schema.sql
@@ -1,0 +1,6 @@
+-- Minimal schema for MysqlStorage
+CREATE TABLE csrf_cache (
+  token_hash VARCHAR(64) PRIMARY KEY,
+  payload    JSON NOT NULL,
+  created_at DATETIME NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset name="CS">
+  <rule ref="PSR12"/>
+  <file>src</file>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite name="CSRF Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+</phpunit>

--- a/src/ArrayStorage.php
+++ b/src/ArrayStorage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace rafalmasiarek\Csrf;
+
+/**
+ * In-memory array storage (useful for testing).
+ */
+class ArrayStorage implements CsrfStorageInterface
+{
+    /** @var array<string,array> */
+    private array $data = [];
+
+    public function store(string $encryptedToken, array $payload): void
+    {
+        $this->data[hash('sha256', $encryptedToken)] = $payload;
+    }
+
+    public function fetch(string $encryptedToken): ?array
+    {
+        $k = hash('sha256', $encryptedToken);
+        return $this->data[$k] ?? null;
+    }
+
+    public function remove(string $encryptedToken): void
+    {
+        unset($this->data[hash('sha256', $encryptedToken)]);
+    }
+}

--- a/src/Csrf.php
+++ b/src/Csrf.php
@@ -159,8 +159,12 @@ class Csrf
             'iat'   => $state['iat'],
         ];
 
-        if (!$cfg['bind_ip']) $payload['ip'] = '';
-        if (!$cfg['bind_ua']) $payload['ua'] = '';
+        if (!$cfg['bind_ip']) {
+            $payload['ip'] = '';
+        }
+        if (!$cfg['bind_ua']) {
+            $payload['ua'] = '';
+        }
 
         $this->lastPayload = $payload;
 
@@ -178,14 +182,18 @@ class Csrf
      */
     public function validateFor(string $containerId, ?string $encrypted): bool
     {
-        if (!$encrypted) return false;
+        if (!$encrypted) {
+            return false;
+        }
 
         [$bucketKey, $cfg] = $this->resolveContainer($containerId);
 
         $derivedKey = $this->deriveContainerKey($containerId, $cfg['pepper']);
         $aad = $this->makeAad($containerId, $cfg['prefix']);
         $payload = $this->decrypt($derivedKey, $encrypted, $aad);
-        if (!$payload) return false;
+        if (!$payload) {
+            return false;
+        }
 
         $this->lastPayload = $payload;
 
@@ -284,7 +292,9 @@ class Csrf
         if (!is_array($state) || !isset($state['iat']) || !is_int($state['iat'])) {
             return null;
         }
-        if ($this->ttl === 0) return PHP_INT_MAX;
+        if ($this->ttl === 0) {
+            return PHP_INT_MAX;
+        }
 
         $elapsed = time() - $state['iat'];
         if ($elapsed >= $this->ttl) {
@@ -342,7 +352,9 @@ class Csrf
         if (!is_array($state) || !isset($state['iat']) || !is_int($state['iat'])) {
             return true;
         }
-        if ($this->ttl === 0) return false;
+        if ($this->ttl === 0) {
+            return false;
+        }
         return (time() - $state['iat']) > $this->ttl;
     }
 
@@ -419,7 +431,9 @@ class Csrf
     private function decrypt(string $key, string $input, string $aad): ?array
     {
         $raw = base64_decode($input, true);
-        if ($raw === false || strlen($raw) < 28) return null;
+        if ($raw === false || strlen($raw) < 28) {
+            return null;
+        }
 
         $iv = substr($raw, 0, 12);
         $tag = substr($raw, 12, 16);
@@ -435,7 +449,9 @@ class Csrf
             $aad
         );
 
-        if ($json === false) return null;
+        if ($json === false) {
+            return null;
+        }
 
         return json_decode($json, true);
     }

--- a/src/Csrf.php
+++ b/src/Csrf.php
@@ -1,80 +1,54 @@
 <?php
 
+declare(strict_types=1);
+
 namespace rafalmasiarek\Csrf;
 
+/**
+ * Container-aware CSRF with AES-256-GCM and per-container isolation.
+ *
+ * Backwards compatibility:
+ *  - generate()/validate()/regenerate()/getExpiresIn()/clear() continue to work
+ *    and operate on the "default" container.
+ *
+ * Security:
+ *  - Each container has its own session bucket, derived key (HKDF), optional pepper,
+ *    and AES-GCM Additional Authenticated Data (AAD) binding.
+ *  - Token payload binds to container id (cid), IP (optional), UA (optional), and iat.
+ */
 class Csrf
 {
-    /**
-     * @var string
-     */
-    // This is the session key used to store the CSRF token in the session.
-    // It is used to retrieve the token during validation.
-    private string $sessionKey = '_csrf_token';
+    /** Root session namespace for all CSRF state. */
+    private string $sessionRoot = '_csrf_v2';
 
-    /**
-     * @var string
-     */
-    // This is the cipher key used for encrypting and decrypting the CSRF token payload.
-    // It must be exactly 32 bytes long for AES-256-GCM encryption.
-    // It is used to ensure the security of the CSRF token.
+    /** Legacy single-key (kept for BC if someone clears manually). */
+    private string $legacySessionKey = '_csrf_token';
+
+    /** Master cipher key (32 bytes). */
     private string $cipherKey;
 
-    /**
-     * @var int
-     */
-    // This is the time-to-live (TTL) for the CSRF token in seconds.
-    // It defines how long the token is valid before it expires.
-    // The default value is set to 900 seconds (15 minutes).
-    // It is used to prevent replay attacks by ensuring that old tokens cannot be reused.
-    // If the token is not used within this time frame, it will be considered invalid.
-    // It is used to enhance security by limiting the lifetime of the token.
-    // It can be adjusted based on the application's security requirements.
-    // For example, if the application requires a shorter validity period for security reasons,
-    // this value can be set to a lower number.
-    // Conversely, if the application needs a longer validity period for usability reasons,
-    // this value can be increased.
-    // The TTL is checked during validation to ensure that the token is still valid.
-    // If the current time exceeds the token's issue time plus the TTL, the token is considered expired.
-    // This helps to mitigate the risk of CSRF attacks by ensuring that tokens cannot be reused indefinitely.
-    // It is a crucial part of the CSRF token's security mechanism.
+    /** Time-to-live (seconds). 0 means never expires. */
     private int $ttl;
 
-    /**
-     * @var array|null
-     */
-    // This property holds the last payload that was generated or validated.
-    // It is used to store the token, IP address, user agent, and issue time.
-    // It is useful for debugging and logging purposes, allowing developers to inspect the last used CSRF token payload.
-    // It is set when a new token is generated or when a token is validated.
-    // It can be accessed using the getLastPayload() method.
-    // It is nullable, meaning it can be null if no token has been generated or validated yet.
-    // This allows the application to check if a token has been used before attempting to validate it.
-    // If no token has been generated or validated, this property will be null.
-    // It is not stored in the session or any persistent storage, but only in memory during
-    // the lifetime of the EncryptedCsrfToken instance.
-    // This property is useful for applications that need to log or debug CSRF token usage.
+    /** Last generated or validated payload. */
     private ?array $lastPayload = null;
 
     /**
-     * Returns the time-to-live (TTL) for CSRF tokens in seconds.
-     *
-     * This value defines how long a generated CSRF token remains valid.
-     *
-     * @return int The TTL in seconds.
+     * Per-container runtime options.
+     * Keys are container IDs, values are option arrays:
+     *  - prefix  (string) : prefix added to session bucket key
+     *  - bind_ip (bool)   : verify client IP (default: true)
+     *  - bind_ua (bool)   : verify User-Agent (default: true)
+     *  - pepper  (?string): optional per-container binary secret for HKDF salt
+     * @var array<string, array{prefix:string,bind_ip:bool,bind_ua:bool,pepper:?string}>
      */
-    public function getTtl(): int
-    {
-        return $this->ttl;
-    }
+    private array $containerOptions = [];
 
     /**
-     * Constructor for the EncryptedCsrfToken.
-     *
-     * @param string $cipherKey The key used for AES-256-GCM encryption (must be 32 bytes).
-     * @param int $ttlSeconds The time-to-live for the token in seconds (default: 900).
-     * @throws \InvalidArgumentException if the cipher key is not exactly 32 bytes.
+     * @param string $cipherKey 32-byte key used for AES-256-GCM encryption.
+     * @param int    $ttlSeconds Token TTL (seconds). 0 disables expiration.
+     * @throws \InvalidArgumentException If $cipherKey length is not exactly 32 bytes.
      */
-    // Initializes the EncryptedCsrfToken instance with a cipher key and an optional TTL.
     public function __construct(string $cipherKey, int $ttlSeconds = 900)
     {
         if (strlen($cipherKey) !== 32) {
@@ -85,86 +59,154 @@ class Csrf
     }
 
     /**
-     * Generates a new CSRF token or reuses an existing one if it is still valid.
+     * Configure/override options for a container ID.
      *
-     * @return string The encrypted CSRF token.
+     * @param string $containerId Container identifier (e.g., 'signup', 'profile').
+     * @param array  $options     See $containerOptions description.
+     * @return $this
      */
-    // This method generates a new CSRF token, encrypts it, and stores it in the session.
-    // It also includes the current IP address, user agent, and issue time in the payload.
-    // The generated token is a random 32-byte hexadecimal string.
-    // The payload is then encrypted using AES-256-GCM with the provided cipher key.
-    // The encrypted token is returned as a base64-encoded string.
-    // This token can be used in forms or AJAX requests to protect against CSRF attacks.
-    // The session key is used to store the token in the user's session, allowing it to
-    // be validated later when the form is submitted or the AJAX request is made.
-    // The token is valid for the duration specified by the TTL (time-to-live).
-    // The payload includes the token, the user's IP address, user agent, and the issue time.
-    // This information is used during validation to ensure that the token is still valid
-    // and has not been tampered with.  
+    public function withContainer(string $containerId, array $options): self
+    {
+        $defaults = [
+            'prefix'  => '',
+            'bind_ip' => true,
+            'bind_ua' => true,
+            'pepper'  => null,
+        ];
+        $this->containerOptions[$containerId] = array_replace($defaults, $options);
+        return $this;
+    }
+
+    /** @return int TTL in seconds (0 means no expiry). */
+    public function getTtl(): int
+    {
+        return $this->ttl;
+    }
+
+    /* ===================== Backwards-compatible API (default container) ===================== */
+
+    /** @return string Encrypted token for the default container. */
     public function generate(): string
     {
-        $state = $_SESSION[$this->sessionKey] ?? null;
-        $hasState = is_array($state) && isset($state['token'], $state['iat']) && is_string($state['token']) && is_int($state['iat']);
+        return $this->generateFor('default');
+    }
+
+    /**
+     * @param string|null $encrypted Encrypted token.
+     * @return bool True if valid for the default container.
+     */
+    public function validate(?string $encrypted): bool
+    {
+        return $this->validateFor('default', $encrypted);
+    }
+
+    /** @return string New encrypted token for the default container. */
+    public function regenerate(): string
+    {
+        return $this->regenerateFor('default');
+    }
+
+    /**
+     * @return int|null Seconds until expiry of the default container token;
+     *                  null if no token; 0 if expired; PHP_INT_MAX if TTL=0.
+     */
+    public function getExpiresIn(): ?int
+    {
+        return $this->getExpiresInFor('default');
+    }
+
+    /** @return array|null Last generated/validated payload. */
+    public function getLastPayload(): ?array
+    {
+        return $this->lastPayload;
+    }
+
+    /** Clear the default container token state. */
+    public function clear(): void
+    {
+        $this->clearFor('default');
+    }
+
+    /* ===================== Container-aware API ===================== */
+
+    /**
+     * Generate (or reuse unexpired) token for a container.
+     *
+     * @param string $containerId Container identifier.
+     * @return string Encrypted token.
+     */
+    public function generateFor(string $containerId): string
+    {
+        [$bucketKey, $cfg] = $this->resolveContainer($containerId);
+
+        $state = $_SESSION[$this->sessionRoot][$bucketKey] ?? null;
+        $hasState = is_array($state) && isset($state['token'], $state['iat'])
+            && is_string($state['token']) && is_int($state['iat']);
 
         if (!$hasState || $this->isExpired($state)) {
             $state = [
                 'token' => bin2hex(random_bytes(32)),
                 'iat'   => time(),
             ];
-            $_SESSION[$this->sessionKey] = $state;
+            $_SESSION[$this->sessionRoot][$bucketKey] = $state;
         }
 
         $payload = [
+            'cid'   => $containerId,
             'token' => $state['token'],
-            'ip' => $_SERVER['REMOTE_ADDR'] ?? '',
-            'ua' => $_SERVER['HTTP_USER_AGENT'] ?? '',
-            'iat' => $state['iat'],
+            'ip'    => $_SERVER['REMOTE_ADDR'] ?? '',
+            'ua'    => $_SERVER['HTTP_USER_AGENT'] ?? '',
+            'iat'   => $state['iat'],
         ];
 
+        if (!$cfg['bind_ip']) $payload['ip'] = '';
+        if (!$cfg['bind_ua']) $payload['ua'] = '';
+
         $this->lastPayload = $payload;
-        return $this->encrypt($payload);
+
+        $derivedKey = $this->deriveContainerKey($containerId, $cfg['pepper']);
+        $aad = $this->makeAad($containerId, $cfg['prefix']);
+        return $this->encrypt($derivedKey, $payload, $aad);
     }
 
     /**
-     * Validates a CSRF token.
+     * Validate an encrypted token for a specific container.
      *
-     * @param string|null $encrypted The encrypted CSRF token to validate.
-     * @return bool True if the token is valid, false otherwise.
+     * @param string      $containerId Container identifier.
+     * @param string|null $encrypted   Encrypted token to validate.
+     * @return bool True on success, false otherwise.
      */
-    // This method validates the provided encrypted CSRF token.
-    // It decrypts the token, checks if it matches the session token,
-    // and verifies the IP address, user agent, and issue time.
-    // If the token is valid, it updates the lastPayload property with the decrypted payload.
-    // It returns true if the token is valid and has not expired, false otherwise.
-    // The validation checks include:
-    // - The token matches the one stored in the session.
-    // - The IP address matches the one from the request.
-    // - The user agent matches the one from the request.
-    // - The issue time is within the allowed TTL (time-to-live).
-    // If any of these checks fail, the token is considered invalid.
-    // If the token is valid, it can be used to protect against CSRF attacks.
-    // This method is typically called when processing a form submission or an AJAX request
-    // to ensure that the request is legitimate and not a CSRF attack.
-    // It is important to call this method before processing any sensitive actions
-    // that require CSRF protection, such as modifying user data or performing actions
-    // that could affect the state of the application.
-    public function validate(?string $encrypted): bool
+    public function validateFor(string $containerId, ?string $encrypted): bool
     {
         if (!$encrypted) return false;
-        $payload = $this->decrypt($encrypted);
+
+        [$bucketKey, $cfg] = $this->resolveContainer($containerId);
+
+        $derivedKey = $this->deriveContainerKey($containerId, $cfg['pepper']);
+        $aad = $this->makeAad($containerId, $cfg['prefix']);
+        $payload = $this->decrypt($derivedKey, $encrypted, $aad);
         if (!$payload) return false;
 
         $this->lastPayload = $payload;
 
-        $state = $_SESSION[$this->sessionKey] ?? null;
+        if (($payload['cid'] ?? null) !== $containerId) {
+            return false;
+        }
+
+        $state = $_SESSION[$this->sessionRoot][$bucketKey] ?? null;
         if (!is_array($state) || !isset($state['token'], $state['iat'])) {
             return false;
         }
 
+        $reqIp = $_SERVER['REMOTE_ADDR'] ?? '';
+        $reqUa = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        $expIp = $cfg['bind_ip'] ? $reqIp : '';
+        $expUa = $cfg['bind_ua'] ? $reqUa : '';
+
         if (
             $payload['token'] !== $state['token'] ||
-            $payload['ip'] !== ($_SERVER['REMOTE_ADDR'] ?? '') ||
-            $payload['ua'] !== ($_SERVER['HTTP_USER_AGENT'] ?? '')
+            ($payload['ip'] ?? '') !== $expIp ||
+            ($payload['ua'] ?? '') !== $expUa
         ) {
             return false;
         }
@@ -173,49 +215,37 @@ class Csrf
             return false;
         }
 
-        $this->clear(); // burn after successful validation
+        $this->clearFor($containerId);
         return true;
     }
 
     /**
-     * Validates a cached CSRF token payload.
+     * Validate a cached payload for a specific container (no decrypt).
      *
-     * @param array $payload The payload to validate.
-     * @return bool True if the payload is valid, false otherwise.
+     * @param string $containerId Container identifier.
+     * @param array  $payload     Cached payload to check.
+     * @return bool True if matches session and not expired.
      */
-    // This method validates a cached CSRF token payload.
-    // It checks if the payload matches the session token, IP address, user agent,
-    // and issue time. It also checks if the token has not expired based on the TTL
-    // (time-to-live).
-    // It is used to validate tokens that have been previously cached, allowing for
-    // efficient validation without needing to decrypt the token again.
-    // The payload should contain the following keys:
-    // - 'token': The CSRF token.
-    // - 'ip': The user's IP address.
-    // - 'ua': The user's user agent.
-    // - 'iat': The issue time of the token.
-    // If the payload is valid, it updates the lastPayload property with the provided payload.
-    // It returns true if the payload is valid and has not expired, false otherwise.
-    // This method is useful in scenarios where the CSRF token has been cached
-    // and needs to be validated without going through the decryption process again.
-    // It can be used in conjunction with a caching mechanism to improve performance
-    // by avoiding repeated decryption of the same token.
-    // It is typically called when the application needs to validate a CSRF token
-    // that has been previously generated and cached, such as when processing a form submission
-    // or an AJAX request that includes the CSRF token in the payload.
-    public function validateCached(array $payload): bool
+    public function validateCachedFor(string $containerId, array $payload): bool
     {
+        [$bucketKey, $cfg] = $this->resolveContainer($containerId);
         $this->lastPayload = $payload;
 
-        $state = $_SESSION[$this->sessionKey] ?? null;
+        $state = $_SESSION[$this->sessionRoot][$bucketKey] ?? null;
         if (!is_array($state) || !isset($state['token'], $state['iat'])) {
             return false;
         }
 
+        $reqIp = $_SERVER['REMOTE_ADDR'] ?? '';
+        $reqUa = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        $expIp = $cfg['bind_ip'] ? $reqIp : '';
+        $expUa = $cfg['bind_ua'] ? $reqUa : '';
+
         if (
-            $payload['token'] !== $state['token'] ||
-            $payload['ip'] !== ($_SERVER['REMOTE_ADDR'] ?? '') ||
-            $payload['ua'] !== ($_SERVER['HTTP_USER_AGENT'] ?? '')
+            ($payload['cid'] ?? null) !== $containerId ||
+            ($payload['token'] ?? null) !== $state['token'] ||
+            ($payload['ip'] ?? '') !== $expIp ||
+            ($payload['ua'] ?? '') !== $expUa
         ) {
             return false;
         }
@@ -224,143 +254,171 @@ class Csrf
             return false;
         }
 
-        unset($_SESSION[$this->sessionKey]); // burn after successful validation
+        unset($_SESSION[$this->sessionRoot][$bucketKey]);
         return true;
     }
 
     /**
-     * Force generate a brand new CSRF token, ignoring any existing one.
+     * Force new token for a container (clears previous state).
      *
-     * @return string The new encrypted CSRF token.
+     * @param string $containerId
+     * @return string New encrypted token.
      */
-    // This method removes any existing token from the session and generates a completely new one.
-    // It can be used when a manual regeneration of the token is required.
-    public function regenerate(): string
+    public function regenerateFor(string $containerId): string
     {
-        unset($_SESSION[$this->sessionKey]);
-        return $this->generate();
+        [$bucketKey] = $this->resolveContainer($containerId);
+        unset($_SESSION[$this->sessionRoot][$bucketKey]);
+        return $this->generateFor($containerId);
     }
 
     /**
-     * Get remaining lifetime of the current CSRF token in seconds.
+     * Remaining lifetime for a container.
      *
-     * @return int|null Remaining seconds, 0 if expired, null if no token exists.
+     * @param string $containerId
+     * @return int|null Seconds remaining, 0 if expired, null if no token, PHP_INT_MAX if TTL=0.
      */
-    // This method returns how many seconds remain before the current token expires.
-    // It returns null if there is no token in the session, or 0 if it has already expired.
-    public function getExpiresIn(): ?int
+    public function getExpiresInFor(string $containerId): ?int
     {
-        $state = $_SESSION[$this->sessionKey] ?? null;
+        [$bucketKey] = $this->resolveContainer($containerId);
+        $state = $_SESSION[$this->sessionRoot][$bucketKey] ?? null;
         if (!is_array($state) || !isset($state['iat']) || !is_int($state['iat'])) {
             return null;
         }
+        if ($this->ttl === 0) return PHP_INT_MAX;
 
         $elapsed = time() - $state['iat'];
         if ($elapsed >= $this->ttl) {
             return 0;
         }
-
         return $this->ttl - $elapsed;
     }
 
     /**
-     * Retrieves the last payload used for the CSRF token.
+     * Clear token for a container.
      *
-     * @return array|null The last payload, or null if no payload has been set.
-     */
-    // This method returns the last payload that was generated or validated.
-    // It can be used to inspect the details of the last CSRF token used,
-    // including the token, IP address, user agent, and issue time.
-    // This is useful for debugging and logging purposes, allowing developers to
-    // see the last used CSRF token payload.
-    // It returns null if no payload has been set, which can happen if no token has
-    // been generated or validated yet.
-    public function getLastPayload(): ?array
-    {
-        return $this->lastPayload;
-    }
-
-    /**
-     * Clears the CSRF token from the session.
-     *
+     * @param string $containerId
      * @return void
      */
-    // This method clears the CSRF token from the session.
-    // It removes the token stored under the session key, effectively invalidating it.
-    // This is useful when you want to reset the CSRF token, for example, after
-    // a successful form submission or when the user logs out.
-    // After calling this method, a new CSRF token will need to be generated
-    // for subsequent requests that require CSRF protection.
-    public function clear(): void
+    public function clearFor(string $containerId): void
     {
-        unset($_SESSION[$this->sessionKey]);
+        [$bucketKey] = $this->resolveContainer($containerId);
+        unset($_SESSION[$this->sessionRoot][$bucketKey]);
+    }
+
+    /* ===================== Internals ===================== */
+
+    /**
+     * Resolve session bucket and merged options for a container.
+     *
+     * @param string $containerId
+     * @return array{0:string,1:array{prefix:string,bind_ip:bool,bind_ua:bool,pepper:?string}}
+     */
+    private function resolveContainer(string $containerId): array
+    {
+        $defaults = [
+            'prefix'  => '',
+            'bind_ip' => true,
+            'bind_ua' => true,
+            'pepper'  => null,
+        ];
+        $cfg = $this->containerOptions[$containerId] ?? $defaults;
+        $bucketKey = ($cfg['prefix'] !== '' ? $cfg['prefix'] : '') . $containerId;
+
+        if (!isset($_SESSION[$this->sessionRoot]) || !is_array($_SESSION[$this->sessionRoot])) {
+            $_SESSION[$this->sessionRoot] = [];
+        }
+
+        return [$bucketKey, $cfg];
     }
 
     /**
-     * Checks whether a given session token state is expired or invalid.
+     * Check if a given session state is expired.
      *
-     * @param array|null $state The session state array.
-     * @return bool True if expired or invalid, false otherwise.
+     * @param array|null $state
+     * @return bool True if expired/invalid.
      */
-    // This private helper method checks if the provided token state is expired or invalid.
-    // It is used internally to avoid repeating TTL validation logic in multiple methods.
     public function isExpired(?array $state): bool
     {
         if (!is_array($state) || !isset($state['iat']) || !is_int($state['iat'])) {
             return true;
         }
+        if ($this->ttl === 0) return false;
         return (time() - $state['iat']) > $this->ttl;
     }
 
     /**
-     * Encrypts the CSRF token payload.
+     * Derive per-container 32-byte key with HKDF(SHA-256).
      *
-     * @param array $data The payload data to encrypt.
-     * @return string The base64-encoded encrypted token.
+     * @param string      $containerId
+     * @param string|null $pepper Binary salt for HKDF-Extract; optional.
+     * @return string 32-byte binary key.
      */
-    // This method encrypts the provided payload data using AES-256-GCM encryption.
-    // It generates a random initialization vector (IV) and uses the cipher key
-    // to encrypt the JSON-encoded payload. The IV and authentication tag are prepended
-    // to the encrypted data, and the result is base64-encoded for easy storage and
-    // transmission.
-    private function encrypt(array $data): string
+    private function deriveContainerKey(string $containerId, ?string $pepper): string
+    {
+        $salt = $pepper ?? '';
+        $prk = hash_hmac('sha256', $this->cipherKey, $salt, true);
+        $info = 'csrf:' . $containerId;
+        $okm = '';
+        $t = '';
+        $len = 32;
+        for ($i = 1; strlen($okm) < $len; $i++) {
+            $t = hash_hmac('sha256', $t . $info . chr($i), $prk, true);
+            $okm .= $t;
+        }
+        return substr($okm, 0, 32);
+    }
+
+    /**
+     * Build Additional Authenticated Data (AAD) for AES-GCM.
+     *
+     * @param string $containerId
+     * @param string $prefix
+     * @return string
+     */
+    private function makeAad(string $containerId, string $prefix): string
+    {
+        return 'cid=' . $containerId . ';prefix=' . $prefix;
+    }
+
+    /**
+     * AES-256-GCM encrypt with AAD. Returns base64(iv|tag|ciphertext).
+     *
+     * @param string $key   32-byte binary key.
+     * @param array  $data  Payload to encrypt.
+     * @param string $aad   Additional authenticated data.
+     * @return string Base64-encoded token.
+     */
+    private function encrypt(string $key, array $data, string $aad): string
     {
         $iv = random_bytes(12);
-        $json = json_encode($data);
+        $json = json_encode($data, JSON_UNESCAPED_SLASHES);
         $tag = '';
 
         $cipher = openssl_encrypt(
             $json,
             'aes-256-gcm',
-            $this->cipherKey,
+            $key,
             OPENSSL_RAW_DATA,
             $iv,
-            $tag
+            $tag,
+            $aad,
+            16
         );
 
         return base64_encode($iv . $tag . $cipher);
     }
 
     /**
-     * Decrypts the CSRF token payload.
+     * AES-256-GCM decrypt with AAD. Accepts base64(iv|tag|ciphertext).
      *
-     * @param string $input The base64-encoded encrypted token.
-     * @return array|null The decrypted payload, or null if decryption fails.
+     * @param string $key   32-byte binary key.
+     * @param string $input Base64 token.
+     * @param string $aad   Additional authenticated data.
+     * @return array|null Decrypted payload, or null on failure.
      */
-    // This method decrypts the provided base64-encoded encrypted token.
-    // It decodes the input, extracts the IV, authentication tag, and ciphertext,
-    // and then uses the cipher key to decrypt the data using AES-256-GCM.
-    // If decryption is successful, it returns the decoded JSON payload as an associative array.
-    // If decryption fails or the input is invalid, it returns null.
-    // The method expects the input to be a base64-encoded string that contains
-    // the IV, tag, and ciphertext concatenated together.
-    // The IV is the first 12 bytes, the tag is the next 16 bytes,
-    // and the ciphertext is the remaining bytes.
-    // This method is used to retrieve the original payload data from the encrypted token,
-    // allowing the application to validate the CSRF token and its associated data.
-    private function decrypt(string $input): ?array
+    private function decrypt(string $key, string $input, string $aad): ?array
     {
-        $raw = base64_decode($input);
+        $raw = base64_decode($input, true);
         if ($raw === false || strlen($raw) < 28) return null;
 
         $iv = substr($raw, 0, 12);
@@ -370,10 +428,11 @@ class Csrf
         $json = openssl_decrypt(
             $ciphertext,
             'aes-256-gcm',
-            $this->cipherKey,
+            $key,
             OPENSSL_RAW_DATA,
             $iv,
-            $tag
+            $tag,
+            $aad
         );
 
         if ($json === false) return null;

--- a/src/CsrfCacheWrapper.php
+++ b/src/CsrfCacheWrapper.php
@@ -1,47 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace rafalmasiarek\Csrf;
 
-use rafalmasiarek\Csrf\Csrf;
-
+/**
+ * Cache wrapper for CSRF validation.
+ *
+ * Caches decrypted payloads keyed by a composite "<container>|<token>" string.
+ * On cache hit, validates IP/UA/TTL quickly without decryption.
+ */
 class CsrfCacheWrapper
 {
-    /**
-     * @var EncryptedCsrfToken
-     */
-    // This class wraps the EncryptedCsrfToken to provide caching functionality.
-    // It checks the cache first before validating the token, and stores the payload
-    // in the cache if validation is successful and not in read-only mode.
-    //
     private Csrf $core;
-
-    /**
-     * @var CsrfStorageInterface
-     */
-    // This interface defines the methods for storing and fetching CSRF tokens.
-    // It is used to cache the CSRF tokens to avoid redundant validations.
     private CsrfStorageInterface $cache;
-
-    /**
-     * @var bool
-     */
-    // This flag indicates whether the wrapper is in read-only mode.
-    // In read-only mode, it will not store any tokens in the cache.
-    // This is useful for scenarios where you want to validate tokens without modifying the cache.
-    // Defaults to false, meaning it will store tokens in the cache.
-    // If set to true, it will only validate tokens without caching them.
     private bool $readOnly;
 
-    /**
-     * Constructor for the CsrfCacheWrapper.
-     *
-     * @param Csrf $core The core CSRF token handler.
-     * @param CsrfStorageInterface $cache The storage interface for caching tokens.
-     * @param bool $readOnly Whether to operate in read-only mode (default: false).
-     */
-    // Initializes the wrapper with the core CSRF token handler and the cache storage.
-    // If readOnly is true, it will not store tokens in the cache.
-    // This allows for flexibility in how the CSRF tokens are validated and cached.
     public function __construct(Csrf $core, CsrfStorageInterface $cache, bool $readOnly = false)
     {
         $this->core = $core;
@@ -49,77 +23,96 @@ class CsrfCacheWrapper
         $this->readOnly = $readOnly;
     }
 
-
-    /**
-     * Generates a CSRF token and stores the payload in cache (if enabled).
-     *
-     * @return string The encrypted CSRF token.
-     */
-    // This method generates a CSRF token using the core CSRF token handler.
-    // It retrieves the last payload from the core handler and stores it in the cache if not in read-only mode.
-    // The generated token is then returned for use in forms or API requests.
-    // This allows for efficient generation and caching of CSRF tokens, improving performance.
-    // The token is encrypted and can be used to protect against CSRF attacks.
-    // It ensures that the token is unique and securely stored.
-    // This method is typically called when rendering a form or preparing an API request.
-    // It is essential for generating secure tokens that can be validated later.
-    // The cache is used to avoid redundant validations of the same token.
+    /** Backwards-compat: default container. */
     public function generate(): string
     {
-        $token = $this->core->generate();
+        return $this->generateFor('default');
+    }
+
+    /** Backwards-compat: default container. */
+    public function validate(string $token): bool
+    {
+        return $this->validateFor('default', $token);
+    }
+
+    /**
+     * Generate and cache for container.
+     *
+     * @param string $containerId
+     * @return string
+     */
+    public function generateFor(string $containerId): string
+    {
+        $token = $this->core->generateFor($containerId);
         $payload = $this->core->getLastPayload();
 
         if (!$this->readOnly && $payload !== null) {
-            $this->cache->store($token, $payload);
+            $this->cache->store($this->composeKey($containerId, $token), $payload);
         }
 
         return $token;
     }
 
     /**
-     * Validates a CSRF token.
+     * Validate with cache fast-path for container.
      *
-     * @param string $token The CSRF token to validate.
-     * @return bool True if the token is valid, false otherwise.
+     * @param string $containerId
+     * @param string $token
+     * @return bool
      */
-    // This method checks if the token is present in the cache.
-    // If it is, it validates the cached payload.
-    // If not, it validates the token using the core CSRF token handler.
-    // If the validation is successful and not in read-only mode, it stores the payload in the cache.
-    // Returns true if the token is valid, false otherwise.
-    // This allows for efficient validation of CSRF tokens by leveraging caching.
-    // It reduces the need for repeated validations of the same token, improving performance.
-    public function validate(string $token): bool
+    public function validateFor(string $containerId, string $token): bool
     {
-        $cached = $this->cache->fetch($token);
+        $cacheKey = $this->composeKey($containerId, $token);
+        $cached = $this->cache->fetch($cacheKey);
 
         if ($cached !== null) {
             $ip = $_SERVER['REMOTE_ADDR'] ?? '';
             $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
 
+            $bindIp = ($cached['ip'] ?? '') !== '';
+            $bindUa = ($cached['ua'] ?? '') !== '';
+
             $isMatch =
-                isset($cached['token'], $cached['ip'], $cached['ua'], $cached['iat']) &&
-                $cached['ip'] === $ip &&
-                $cached['ua'] === $ua &&
-                !$this->core->isExpired($cached);
+                isset($cached['cid'], $cached['token'], $cached['iat']) &&
+                $cached['cid'] === $containerId &&
+                (!$bindIp || $cached['ip'] === $ip) &&
+                (!$bindUa || $cached['ua'] === $ua) &&
+                !$this->core->isExpired(['iat' => $cached['iat']]);
 
             if ($isMatch) {
-                return true; // ✅ fast path — validated from cache
+                return true;
             }
         }
 
-        // fallback to core decrypt/validate
-        if (!$this->core->validate($token)) {
+        if (!$this->core->validateFor($containerId, $token)) {
             return false;
         }
 
         if (!$this->readOnly) {
             $payload = $this->core->getLastPayload();
             if ($payload !== null) {
-                $this->cache->store($token, $payload);
+                $this->cache->store($cacheKey, $payload);
             }
         }
 
         return true;
+    }
+
+    /**
+     * Remove a cached entry (optional helper).
+     *
+     * @param string $containerId
+     * @param string $token
+     * @return void
+     */
+    public function removeCached(string $containerId, string $token): void
+    {
+        $this->cache->remove($this->composeKey($containerId, $token));
+    }
+
+    /** Compose composite cache key. */
+    private function composeKey(string $containerId, string $token): string
+    {
+        return $containerId . '|' . $token;
     }
 }

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -36,7 +36,9 @@ class FileStorage implements CsrfStorageInterface
     public function fetch(string $encryptedToken): ?array
     {
         $path = $this->pathFor($encryptedToken);
-        if (!is_file($path)) return null;
+        if (!is_file($path)) {
+            return null;
+        }
         $json = file_get_contents($path);
         return $json ? json_decode($json, true) : null;
     }
@@ -45,7 +47,9 @@ class FileStorage implements CsrfStorageInterface
     public function remove(string $encryptedToken): void
     {
         $path = $this->pathFor($encryptedToken);
-        if (is_file($path)) @unlink($path);
+        if (is_file($path)) {
+            @unlink($path);
+        }
     }
 
     private function pathFor(string $key): string

--- a/src/FileStorage.php
+++ b/src/FileStorage.php
@@ -1,95 +1,56 @@
 <?php
 
+declare(strict_types=1);
+
 namespace rafalmasiarek\Csrf;
 
 /**
- * FileStorage is a simple file-based implementation of the CsrfStorageInterface.
- * It stores CSRF tokens and their associated payloads in JSON files.
+ * File-based CsrfStorageInterface.
+ * Stores entries under hashed filenames to avoid leaking token information.
  */
 class FileStorage implements CsrfStorageInterface
 {
-    /**
-     * Directory where CSRF token files are stored.
-     * Each token is stored in a file named by its SHA-256 hash.
-     *
-     * @var string
-     */
     private string $dir;
 
     /**
-     * Constructor for the FileStorage class.
-     *
-     * @param string $dir The directory where CSRF token files will be stored.
-     *                    It will be created if it does not exist.
+     * @param string $dir Directory to store cache files (must be writable).
      */
-    // Initializes the storage directory and ensures it exists.
-    // The directory is set to be writable only by the owner (0700 permissions).
-    // The directory path is normalized to ensure it ends with a slash.
-    // If the directory does not exist, it will be created with the specified permissions.
     public function __construct(string $dir)
     {
-        $this->dir = rtrim($dir, '/') . '/';
+        $this->dir = rtrim($dir, DIRECTORY_SEPARATOR);
         if (!is_dir($this->dir)) {
-            mkdir($this->dir, 0700, true);
+            if (!@mkdir($this->dir, 0775, true) && !is_dir($this->dir)) {
+                throw new \RuntimeException('Failed to create directory: ' . $this->dir);
+            }
         }
     }
 
-    /**
-     * Store a CSRF token and its associated payload.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     * @param array $payload The payload associated with the CSRF token.
-     */
-    // This method stores the CSRF token payload in a JSON file.
-    // The file is named using the SHA-256 hash of the token key to ensure uniqueness.
-    // The payload is encoded as JSON and written to the file.
-    // If the file already exists, it will be overwritten.
-    public function store(string $key, array $payload): void
+    /** @inheritDoc */
+    public function store(string $encryptedToken, array $payload): void
     {
-        file_put_contents($this->dir . hash('sha256', $key) . '.json', json_encode($payload));
+        $path = $this->pathFor($encryptedToken);
+        file_put_contents($path, json_encode($payload, JSON_UNESCAPED_SLASHES));
     }
 
-    /**
-     * Fetch the payload associated with a CSRF token.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     * @return array|null The payload if found, null otherwise.
-     */
-    // This method retrieves the CSRF token payload from the corresponding JSON file.
-    // It checks if the file exists and reads its contents.
-    // If the file does not exist, it returns null.
-    // If the file exists, it decodes the JSON content and returns it as an associative array.
-    // If the JSON decoding fails, it will return null.
-    // The file is named using the SHA-256 hash of the token key to ensure uniqueness.
-    // This allows for efficient storage and retrieval of CSRF token data.
-    // The method returns null if the token is not found.
-    // This is useful for validating CSRF tokens and retrieving their associated data.
-    // The payload can include additional information such as user ID, timestamp, or any other relevant
-    // data that was stored when the token was created.
-    public function fetch(string $key): ?array
+    /** @inheritDoc */
+    public function fetch(string $encryptedToken): ?array
     {
-        $path = $this->dir . hash('sha256', $key) . '.json';
-        if (!file_exists($path)) return null;
-        return json_decode(file_get_contents($path), true);
+        $path = $this->pathFor($encryptedToken);
+        if (!is_file($path)) return null;
+        $json = file_get_contents($path);
+        return $json ? json_decode($json, true) : null;
     }
 
-    /**
-     * Remove a CSRF token and its associated payload.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     */
-    // This method deletes the CSRF token file associated with the given key.
-    // It constructs the file path using the SHA-256 hash of the token key.
-    // If the file exists, it will be removed.
-    // This is useful for cleaning up expired or invalid tokens.
-    // It ensures that the storage does not retain unnecessary data, which can help manage disk space
-    // and improve performance by reducing the number of files in the storage directory.
-    // The method does not return any value.
-    // It simply performs the deletion operation.
-    // If the file does not exist, it will do nothing.
-    public function remove(string $key): void
+    /** @inheritDoc */
+    public function remove(string $encryptedToken): void
     {
-        $path = $this->dir . hash('sha256', $key) . '.json';
-        if (file_exists($path)) unlink($path);
+        $path = $this->pathFor($encryptedToken);
+        if (is_file($path)) @unlink($path);
+    }
+
+    private function pathFor(string $key): string
+    {
+        $hash = hash('sha256', $key);
+        return $this->dir . DIRECTORY_SEPARATOR . $hash . '.json';
     }
 }

--- a/src/Helpers/Blade/CsrfBlade.php
+++ b/src/Helpers/Blade/CsrfBlade.php
@@ -8,42 +8,56 @@ use rafalmasiarek\Csrf\Csrf;
 
 /**
  * Blade helper for registering a @csrfField('container') directive.
+ *
  * Usage:
  *   \rafalmasiarek\Csrf\Helpers\Blade\CsrfBlade::register($bladeCompiler, $csrf);
  */
 final class CsrfBlade
 {
     /**
-     * @param object $bladeCompiler Instance of Illuminate\View\Compilers\BladeCompiler.
+     * @param object $bladeCompiler Instance of Illuminate\View\Compilers\BladeCompiler
      * @param Csrf   $csrf
      * @param string $defaultContainer
      * @param string $inputName
      */
-    public static function register(object $bladeCompiler, Csrf $csrf, string $defaultContainer = 'default', string $inputName = '_csrf'): void
-    {
+    public static function register(
+        object $bladeCompiler,
+        Csrf $csrf,
+        string $defaultContainer = 'default',
+        string $inputName = '_csrf'
+    ): void {
         if (!method_exists($bladeCompiler, 'directive')) {
-            throw new \InvalidArgumentException('Provided Blade compiler does not support directive()');
+            throw new \InvalidArgumentException(
+                'Provided Blade compiler does not support directive()'
+            );
         }
 
-        $bladeCompiler->directive('csrfField', function (?string $containerExpression = null) use ($csrf, $defaultContainer, $inputName) {
-            // $containerExpression comes like: "'signup'" or null
-            $code = <<<'PHP'
+        $bladeCompiler->directive(
+            'csrfField',
+            function (?string $containerExpression = null) use ($defaultContainer, $inputName): string {
+                // $containerExpression comes like: "'signup'" or null
+                $code = <<<'PHP'
 <?php
 $__container = %s;
-$__container = $__container === null ? %s : trim($__container, "'"");
-$__token = (function($csrf, $container, $name) {
-    return \rafalmasiarek\Csrf\Helpers\HtmlHelper::input($csrf, $container, $name);
-})(app()->make(%s::class), $__container, %s);
+$__container = $__container === null ? %s : trim($__container, '\'"');
+$__token = (function ($container, $name) {
+    return \rafalmasiarek\Csrf\Helpers\HtmlHelper::input(
+        app()->make(\rafalmasiarek\Csrf\Csrf::class),
+        $container,
+        $name
+    );
+})($__container, %s);
 echo $__token;
 ?>
 PHP;
-            return sprintf(
-                $code,
-                $containerExpression ?? 'null',
-                var_export($defaultContainer, true),
-                var_export(Csrf::class, true),
-                var_export($inputName, true)
-            );
-        });
+
+                return sprintf(
+                    $code,
+                    $containerExpression ?? 'null',
+                    var_export($defaultContainer, true),
+                    var_export($inputName, true)
+                );
+            }
+        );
     }
 }

--- a/src/Helpers/Blade/CsrfBlade.php
+++ b/src/Helpers/Blade/CsrfBlade.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace rafalmasiarek\Csrf\Helpers\Blade;

--- a/src/Helpers/Blade/CsrfBlade.php
+++ b/src/Helpers/Blade/CsrfBlade.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+namespace rafalmasiarek\Csrf\Helpers\Blade;
+
+use rafalmasiarek\Csrf\Csrf;
+
+/**
+ * Blade helper for registering a @csrfField('container') directive.
+ * Usage:
+ *   \rafalmasiarek\Csrf\Helpers\Blade\CsrfBlade::register($bladeCompiler, $csrf);
+ */
+final class CsrfBlade
+{
+    /**
+     * @param object $bladeCompiler Instance of Illuminate\View\Compilers\BladeCompiler.
+     * @param Csrf   $csrf
+     * @param string $defaultContainer
+     * @param string $inputName
+     */
+    public static function register(object $bladeCompiler, Csrf $csrf, string $defaultContainer = 'default', string $inputName = '_csrf'): void
+    {
+        if (!method_exists($bladeCompiler, 'directive')) {
+            throw new \InvalidArgumentException('Provided Blade compiler does not support directive()');
+        }
+
+        $bladeCompiler->directive('csrfField', function (?string $containerExpression = null) use ($csrf, $defaultContainer, $inputName) {
+            // $containerExpression comes like: "'signup'" or null
+            $code = <<<'PHP'
+<?php
+$__container = %s;
+$__container = $__container === null ? %s : trim($__container, "'"");
+$__token = (function($csrf, $container, $name) {
+    return \rafalmasiarek\Csrf\Helpers\HtmlHelper::input($csrf, $container, $name);
+})(app()->make(%s::class), $__container, %s);
+echo $__token;
+?>
+PHP;
+            return sprintf(
+                $code,
+                $containerExpression ?? 'null',
+                var_export($defaultContainer, true),
+                var_export(Csrf::class, true),
+                var_export($inputName, true)
+            );
+        });
+    }
+}

--- a/src/Helpers/HtmlHelper.php
+++ b/src/Helpers/HtmlHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace rafalmasiarek\Csrf\Helpers;

--- a/src/Helpers/HtmlHelper.php
+++ b/src/Helpers/HtmlHelper.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace rafalmasiarek\Csrf\Helpers;
+
+use rafalmasiarek\Csrf\Csrf;
+
+/**
+ * Generic HTML helper for rendering CSRF inputs.
+ */
+final class HtmlHelper
+{
+    /**
+     * Render a hidden <input> with CSRF token for a given container.
+     *
+     * @param Csrf   $csrf
+     * @param string $containerId Container name (default: "default").
+     * @param string $inputName   Input field name (default: "_csrf").
+     * @return string HTML string, already escaped.
+     */
+    public static function input(Csrf $csrf, string $containerId = 'default', string $inputName = '_csrf'): string
+    {
+        $token = $csrf->generateFor($containerId);
+        $value = htmlspecialchars($token, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $name  = htmlspecialchars($inputName, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        return sprintf('<input type="hidden" name="%s" value="%s">', $name, $value);
+    }
+}

--- a/src/Helpers/Plates/CsrfExtension.php
+++ b/src/Helpers/Plates/CsrfExtension.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace rafalmasiarek\Csrf\Helpers\Plates;
+
+use League\Plates\Engine;
+use rafalmasiarek\Csrf\Csrf;
+use rafalmasiarek\Csrf\Helpers\HtmlHelper;
+
+/**
+ * Plates extension to expose csrf_field() function.
+ */
+final class CsrfExtension
+{
+    public static function register(Engine $engine, Csrf $csrf, string $defaultContainer = 'default', string $inputName = '_csrf'): void
+    {
+        $engine->registerFunction('csrf_field', function (?string $container = null) use ($csrf, $defaultContainer, $inputName) {
+            return HtmlHelper::input($csrf, $container ?? $defaultContainer, $inputName);
+        });
+    }
+}

--- a/src/Helpers/Plates/CsrfExtension.php
+++ b/src/Helpers/Plates/CsrfExtension.php
@@ -9,14 +9,35 @@ use rafalmasiarek\Csrf\Csrf;
 use rafalmasiarek\Csrf\Helpers\HtmlHelper;
 
 /**
- * Plates extension to expose csrf_field() function.
+ * Plates extension to expose csrf_token() and csrf_field().
  */
 final class CsrfExtension
 {
-    public static function register(Engine $engine, Csrf $csrf, string $defaultContainer = 'default', string $inputName = '_csrf'): void
-    {
-        $engine->registerFunction('csrf_field', function (?string $container = null) use ($csrf, $defaultContainer, $inputName) {
-            return HtmlHelper::input($csrf, $container ?? $defaultContainer, $inputName);
-        });
+    public static function register(
+        Engine $engine,
+        Csrf $csrf,
+        string $defaultContainer = 'default',
+        string $inputName = '_csrf'
+    ): void {
+        $engine->registerFunction(
+            'csrf_token',
+            function (?string $container = null) use ($csrf, $defaultContainer): string {
+                return HtmlHelper::token(
+                    $csrf,
+                    $container ?? $defaultContainer
+                );
+            }
+        );
+
+        $engine->registerFunction(
+            'csrf_field',
+            function (?string $container = null) use ($csrf, $defaultContainer, $inputName): string {
+                return HtmlHelper::input(
+                    $csrf,
+                    $container ?? $defaultContainer,
+                    $inputName
+                );
+            }
+        );
     }
 }

--- a/src/Helpers/Plates/CsrfExtension.php
+++ b/src/Helpers/Plates/CsrfExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace rafalmasiarek\Csrf\Helpers\Plates;

--- a/src/Helpers/Twig/CsrfExtension.php
+++ b/src/Helpers/Twig/CsrfExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace rafalmasiarek\Csrf\Helpers\Twig;

--- a/src/Helpers/Twig/CsrfExtension.php
+++ b/src/Helpers/Twig/CsrfExtension.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace rafalmasiarek\Csrf\Helpers\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+use rafalmasiarek\Csrf\Csrf;
+use rafalmasiarek\Csrf\Helpers\HtmlHelper;
+
+/**
+ * Twig extension providing {{ csrf_field('container')|raw }}.
+ */
+final class CsrfExtension extends AbstractExtension
+{
+    private Csrf $csrf;
+    private string $defaultContainer;
+    private string $inputName;
+
+    public function __construct(Csrf $csrf, string $defaultContainer = 'default', string $inputName = '_csrf')
+    {
+        $this->csrf = $csrf;
+        $this->defaultContainer = $defaultContainer;
+        $this->inputName = $inputName;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('csrf_field', function (?string $container = null): string {
+                return HtmlHelper::input($this->csrf, $container ?? $this->defaultContainer, $this->inputName);
+            }),
+        ];
+    }
+}

--- a/src/MysqlStorage.php
+++ b/src/MysqlStorage.php
@@ -1,73 +1,44 @@
 <?php
 
+declare(strict_types=1);
+
 namespace rafalmasiarek\Csrf;
 
 use PDO;
 
 /**
- * MysqlStorage is a MySQL-based implementation of the CsrfStorageInterface.
- * It stores CSRF tokens and their associated payloads in a MySQL database.
+ * MySQL-based implementation of CsrfStorageInterface.
+ *
+ * Schema (example):
+ *   CREATE TABLE csrf_cache (
+ *     token_hash VARCHAR(64) PRIMARY KEY,
+ *     payload    JSON NOT NULL,
+ *     created_at DATETIME NOT NULL
+ *   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+ *
+ * Notes:
+ *   - We hash whatever key we get. For multi-container, pass a composite key
+ *     like "<container>|<token>" to avoid cross-container collisions.
  */
 class MysqlStorage implements CsrfStorageInterface
 {
-    /**
-     * @var PDO
-     * The PDO instance used to interact with the MySQL database.
-     * It should be initialized with a valid DSN, username, and password.
-     */
     private PDO $pdo;
 
-    /**
-     * Constructor for the MysqlStorage class.
-     *
-     * @param PDO $pdo The PDO instance for database interactions.
-     *                 It should be connected to a MySQL database with a table named 'csrf_cache'.
-     *                 The table should have columns: token_hash (VARCHAR), payload (TEXT), created_at (DATETIME).
-     */
-    // Initializes the storage with a PDO instance.
-    // The PDO instance should be connected to a MySQL database.
     public function __construct(PDO $pdo)
     {
         $this->pdo = $pdo;
     }
 
-    /**
-     * Store a CSRF token and its associated payload.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     * @param array $payload The payload associated with the CSRF token.
-     */
-    // This method stores the CSRF token payload in the MySQL database.
-    // It uses a prepared statement to prevent SQL injection.
-    // The token is hashed using SHA-256 to ensure uniqueness.
-    // The payload is stored as a JSON string in the 'payload' column.
-    // If a token with the same hash already exists, it will be replaced.
-    // The 'created_at' column is set to the current timestamp.
-    // The table should have been created with the following SQL:
-    // CREATE TABLE csrf_cache (
-    //     token_hash VARCHAR(64) PRIMARY KEY,
-    //     payload TEXT NOT NULL,
-    //     created_at DATETIME NOT NULL
-    // );
-    // The 'token_hash' column is indexed for faster lookups.
-    // The 'payload' column can store large JSON objects.
-    // The 'created_at' column is used to track when the token was created.
-    // This method does not return any value.
-    // It will throw an exception if the database operation fails.
+    /** @inheritDoc */
     public function store(string $key, array $payload): void
     {
-        $stmt = $this->pdo->prepare("REPLACE INTO csrf_cache (token_hash, payload, created_at) VALUES (?, ?, NOW())");
-        $stmt->execute([hash('sha256', $key), json_encode($payload)]);
+        $stmt = $this->pdo->prepare(
+            "REPLACE INTO csrf_cache (token_hash, payload, created_at) VALUES (?, ?, NOW())"
+        );
+        $stmt->execute([hash('sha256', $key), json_encode($payload, JSON_UNESCAPED_SLASHES)]);
     }
 
-
-    /**
-     * Fetch the payload associated with a CSRF token.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     * @return array|null The payload if found, null otherwise.
-     */
-    // This method retrieves the CSRF token payload from the MySQL database.
+    /** @inheritDoc */
     public function fetch(string $key): ?array
     {
         $stmt = $this->pdo->prepare("SELECT payload FROM csrf_cache WHERE token_hash = ?");
@@ -76,12 +47,7 @@ class MysqlStorage implements CsrfStorageInterface
         return $row ? json_decode($row['payload'], true) : null;
     }
 
-    /**
-     * Remove a CSRF token and its associated payload.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     */
-    // This method removes a CSRF token from the MySQL database.
+    /** @inheritDoc */
     public function remove(string $key): void
     {
         $stmt = $this->pdo->prepare("DELETE FROM csrf_cache WHERE token_hash = ?");

--- a/src/RedisStorage.php
+++ b/src/RedisStorage.php
@@ -1,82 +1,50 @@
 <?php
 
+declare(strict_types=1);
+
 namespace rafalmasiarek\Csrf;
 
-use Redis;
-
 /**
- * RedisStorage is a Redis-based implementation of the CsrfStorageInterface.
- * It stores CSRF tokens and their associated payloads in Redis.
+ * Redis-based CsrfStorageInterface.
+ * Uses PHP Redis extension (\Redis) with simple set/get/del operations.
  */
 class RedisStorage implements CsrfStorageInterface
 {
-    /**
-     * @var Redis
-     * The Redis instance used to interact with the Redis database.
-     * It should be initialized with a valid connection to a Redis server.
-     */
-    private Redis $redis;
-
-    /**
-     * @var int
-     * The time-to-live (TTL) for CSRF tokens in seconds.
-     * Defaults to 900 seconds (15 minutes).
-     */
+    private \Redis $redis;
+    private string $prefix;
     private int $ttl;
 
     /**
-     * Constructor for the RedisStorage class.
-     *
-     * @param Redis $redis The Redis instance for database interactions.
-     *                     It should be connected to a Redis server.
-     * @param int $ttl The time-to-live (TTL) for CSRF tokens in seconds (default: 900).
+     * @param \Redis $redis Connected Redis client.
+     * @param string  $prefix Key prefix (default: "csrf:").
+     * @param int     $ttl    TTL for cache entries in seconds (default: 900).
      */
-    public function __construct(Redis $redis, int $ttl = 900)
+    public function __construct(\Redis $redis, string $prefix = 'csrf:', int $ttl = 900)
     {
         $this->redis = $redis;
+        $this->prefix = $prefix;
         $this->ttl = $ttl;
     }
 
-    /**
-     * Store a CSRF token and its associated payload.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     * @param array $payload The payload associated with the CSRF token.
-     */
-    // This method stores the CSRF token payload in Redis.
-    // The key is prefixed with 'csrf:' and hashed using SHA-256 to ensure uniqueness.
-    // The payload is encoded as JSON and stored with an expiration time defined by $ttl.
-    // If a token with the same key already exists, it will be overwritten.
-    // The TTL ensures that the token will be automatically removed after the specified time.
-    // This method does not return any value.
+    /** @inheritDoc */
     public function store(string $key, array $payload): void
     {
-        $this->redis->setex('csrf:' . hash('sha256', $key), $this->ttl, json_encode($payload));
+        $redisKey = $this->prefix . hash('sha256', $key);
+        $this->redis->set($redisKey, json_encode($payload, JSON_UNESCAPED_SLASHES), $this->ttl);
     }
 
-    /**
-     * Fetch the payload associated with a CSRF token.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     * @return array|null The payload if found, null otherwise.
-     */
-    // This method retrieves the CSRF token payload from Redis.
-    // It checks if the key exists in Redis, and if it does, it decodes the JSON content and returns it as an associative array.
-    // If the key does not exist, it returns null.
+    /** @inheritDoc */
     public function fetch(string $key): ?array
     {
-        $raw = $this->redis->get('csrf:' . hash('sha256', $key));
+        $redisKey = $this->prefix . hash('sha256', $key);
+        $raw = $this->redis->get($redisKey);
         return $raw ? json_decode($raw, true) : null;
     }
 
-    /**
-     * Remove a CSRF token and its associated payload.
-     *
-     * @param string $key The CSRF token key (will be hashed).
-     */
-    // This method removes a CSRF token from Redis.
+    /** @inheritDoc */
     public function remove(string $key): void
     {
-        $this->redis->del(['csrf:' . hash('sha256', $key)]);
+        $redisKey = $this->prefix . hash('sha256', $key);
+        $this->redis->del($redisKey);
     }
 }

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use rafalmasiarek\Csrf\Csrf;
+
+final class CsrfTest extends TestCase
+{
+    public function testGenerateAndValidateDefault(): void
+    {
+        $csrf = new Csrf(str_repeat('A', 32), 900);
+        $token = $csrf->generate();
+        $this->assertIsString($token);
+        $this->assertTrue($csrf->validate($token));
+    }
+
+    public function testContainerIsolation(): void
+    {
+        $csrf = (new Csrf(str_repeat('B', 32), 900))
+            ->withContainer('formA', [])
+            ->withContainer('formB', []);
+
+        $tokenA = $csrf->generateFor('formA');
+        $this->assertTrue($csrf->validateFor('formA', $tokenA));
+        $this->assertFalse($csrf->validateFor('formB', $tokenA));
+    }
+
+    public function testBindingsCanBeDisabled(): void
+    {
+        $csrf = (new Csrf(str_repeat('C', 32), 900))
+            ->withContainer('loose', ['bind_ip' => false, 'bind_ua' => false]);
+
+        $token = $csrf->generateFor('loose');
+        $_SERVER['REMOTE_ADDR'] = '10.1.2.3';
+        $_SERVER['HTTP_USER_AGENT'] = 'changed/ua';
+        $this->assertTrue($csrf->validateFor('loose', $token));
+    }
+
+    public function testExpiration(): void
+    {
+        $csrf = new Csrf(str_repeat('D', 32), 1);
+        $token = $csrf->generate();
+        sleep(2);
+        $this->assertFalse($csrf->validate($token));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+@session_start();
+$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+$_SERVER['HTTP_USER_AGENT'] = 'phpunit/1.0';


### PR DESCRIPTION
- Add per-form “containers” to CSRF core:
  - Separate session buckets under $_SESSION['_csrf_v2'][<prefix><container>]
  - Per-container HKDF-derived key (optional pepper) and AES-GCM AAD binding
  - Configurable IP/UA binding per container
  - Burn-after-use per container
  - TTL=0 supported (never expires) — use with caution
- Keep backward compatibility:
  - `generate()` / `validate()` continue to operate on the "default" container
- Add helpers for templating engines:
  - Generic `HtmlHelper::token()` and `HtmlHelper::field()`
  - Plates: `csrf_token()` and `csrf_field()`
  - Twig: `csrf_token()` and `csrf_field()`
  - Blade: `@csrfToken()` and `@csrfField()`
- Provide “token only” option (no HTML) across helpers
- Add cache-aware wrapper:
  - `CsrfCacheWrapper::generateFor()` / `validateFor()` with composite cache keys `<container>|<token>`
- Storage implementations:
  - File, MySQL, Redis updated with PHPDocs and notes for composite keys
  - New `ArrayStorage` for tests/dev
- Documentation:
  - Expanded README: quick start, containers, helpers, security notes
  - Migration guide 1.1.x → 1.2.0 (no breaking changes for default usage)
- Examples:
  - Consolidate into existing `example/` structure
  - Add `example/containers/index.php` and `example/mysql/schema.sql`
- Tooling:
  - PHPUnit tests + `phpunit.xml.dist` and bootstrap
  - PHPCS (PSR-12) + `phpcs.xml.dist`
  - GitHub Actions CI (PHP 8.1/8.2/8.3 matrix, tests + CS)
- Composer:
  - Ensure PSR-4 autoload for `rafalmasiarek\Csrf\`
  - Add dev requirements and scripts (`test`, `cs`)

Security notes:
- Master key must be 32 bytes and kept secret; rotate periodically
- Prefer enabling IP/UA binding unless your environment requires loosening
- Use reasonable TTLs; avoid 0 unless you fully understand the implications